### PR TITLE
fix typo: beind -> behind

### DIFF
--- a/notebooks/ch5.ipynb
+++ b/notebooks/ch5.ipynb
@@ -345,7 +345,7 @@
     "\n",
     "Queries with unbounded sensitivity cannot be directly answered with differential privacy using the Laplace mechanism. Fortunately, we can often transform such queries into equivalent queries with *bounded* sensitivity, via a process called *clipping*.\n",
     "\n",
-    "The basic idea beind clipping is to *enforce* upper and lower bounds on attribute values. For example, ages above 125 can be \"clipped\" to exactly 125. After clipping has been performed, we are *guaranteed* that all ages will be 125 or below. As a result, the senstivity of a summation query on clipped data is equal to the difference between the upper and lower bounds used in clipping: $upper - lower$. For example, the following query has a sensitivity of 125:"
+    "The basic idea behind clipping is to *enforce* upper and lower bounds on attribute values. For example, ages above 125 can be \"clipped\" to exactly 125. After clipping has been performed, we are *guaranteed* that all ages will be 125 or below. As a result, the senstivity of a summation query on clipped data is equal to the difference between the upper and lower bounds used in clipping: $upper - lower$. For example, the following query has a sensitivity of 125:"
    ]
   },
   {


### PR DESCRIPTION
Just fix a typo

Now I am reading these notebooks and they are very useful to learn differential privacy. Thanks.