### PR TITLE
Update ch2.ipynb

### DIFF
--- a/notebooks/ch2.ipynb
+++ b/notebooks/ch2.ipynb
@@ -698,7 +698,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll consider the ZIP code, age, and educational achievement of each individual to be the quasi-identifiers. We'll project just those columns, and try to achieve $k$-Anonymity for $k=2$. The data is already $k$-Anonymous for $k=1$.\n",
+    "We'll consider the age, and educational achievement of each individual to be the quasi-identifiers. We'll project just those columns, and try to achieve $k$-Anonymity for $k=2$. The data is already $k$-Anonymous for $k=1$.\n",
     "\n",
     "Notice that we take just the first 100 rows from the dataset for this check - try running `isKAnonymized` on a larger subset of the data, and you'll find that it takes a very long time (for example, running the $k=1$ check on 5000 rows takes about 20 seconds on my laptop). For $k=2$, our algorithm finds a failing row quickly and finishes fast."
    ]


### PR DESCRIPTION
When I am reading, I find that the example code behind doesn't use ZIP code as quasi_identifiers. So, I thinking "ZIP code" in this part should be removed.